### PR TITLE
Fix CrowdSec LAPI user agent format

### DIFF
--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func main() {
 	bouncer := &csbouncer.StreamBouncer{
 		APIKey:              pluginConfig.APIKey,
 		APIUrl:              pluginConfig.AgentUrl,
-		UserAgent:           info.BOUNCER_TYPE + "-" + info.VERSION_STRING,
+		UserAgent:           info.BOUNCER_USER_AGENT,
 		TickerInterval:      pluginConfig.StreamUpdateFrequency,
 		Scopes:              []string{"ip", "range"},
 		RetryInitialConnect: true,

--- a/mod/info/info.go
+++ b/mod/info/info.go
@@ -10,9 +10,11 @@ const (
 	CONFIGURATION_FILE      = "./config.yaml"
 	BOUNCER_TYPE            = "zoraxy-crowdsec-bouncer"
 
-	VERSION_MAJOR = 1
-	VERSION_MINOR = 2
-	VERSION_PATCH = 2
-
+	VERSION_MAJOR  = 1
+	VERSION_MINOR  = 2
+	VERSION_PATCH  = 2
 	VERSION_STRING = "v1.2.2"
+
+	// BOUNCER_USER_AGENT must use the name/version format expected by CrowdSec's LAPI.
+	BOUNCER_USER_AGENT = BOUNCER_TYPE + "/" + VERSION_STRING
 )

--- a/mod/info/info_test.go
+++ b/mod/info/info_test.go
@@ -1,0 +1,13 @@
+package info
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBouncerUserAgentUsesLAPIFormat(t *testing.T) {
+	parts := strings.Split(BOUNCER_USER_AGENT, "/")
+	if len(parts) != 2 || parts[0] != BOUNCER_TYPE || parts[1] != VERSION_STRING {
+		t.Fatalf("invalid CrowdSec LAPI user agent %q", BOUNCER_USER_AGENT)
+	}
+}


### PR DESCRIPTION
## Summary

- Send the bouncer User-Agent in the CrowdSec LAPI-required `name/version` format.
- Add a regression test for that format.

## Root cause

The previous `name-version` value is rejected by CrowdSec LAPI as a bad user agent. The bouncer therefore cannot fetch decisions and does not block requests.

## Validation

- `go test ./...`

Fixes #32
