### PR TITLE
feat(web): show recent blocked connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ The web UI is available from the Zoraxy web interface in the "Plugins" section.
 
 In it, you can view some basic information about the bouncer, such as the number of requests processed and dropped by the bouncer for each hostname.
 
+The UI also shows the most recent 200 blocked connections from the current plugin session. To avoid retaining secrets, it stores only masked client networks, the hostname, request method and path (without query string), and CrowdSec decision metadata. It never stores request headers or bodies.
+
 ### Onboarding Mode
 
 If `api_key` is not set yet, the plugin starts in onboarding mode. In this state,

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ agent_url: http://127.0.0.1:8080 # for example
 stream_update_frequency: 10s # How often to retrieve decision deltas from CrowdSec
 log_level: warning # Log level for the bouncer, options: trace, debug, info, warning, error
 is_proxied_behind_cloudflare: true # Set to true if your zoraxy instance is proxied behind Cloudflare
+# Display client IPs in Recent Blocked Connections: masked (default) or full
+blocked_events_ip_mode: masked
 ```
 
 You can get the API key by running the following command:
@@ -131,7 +133,9 @@ The web UI is available from the Zoraxy web interface in the "Plugins" section.
 
 In it, you can view some basic information about the bouncer, such as the number of requests processed and dropped by the bouncer for each hostname.
 
-The UI also shows the most recent 200 blocked connections from the current plugin session. To avoid retaining secrets, it stores only masked client networks, the hostname, request method and path (without query string), and CrowdSec decision metadata. It never stores request headers or bodies.
+The UI also shows the most recent 200 blocked connections from the current plugin session. It stores the hostname, request method and path (without query string), and CrowdSec decision metadata; it never stores request headers or bodies.
+
+`blocked_events_ip_mode` controls the client address shown in this table. The default, `masked`, stores IPv4 addresses as `/24` and IPv6 addresses as `/64` networks. Set it to `full` only when the Zoraxy administration UI is restricted to trusted users and you need exact IPs for incident correlation.
 
 ### Onboarding Mode
 

--- a/config.yaml
+++ b/config.yaml
@@ -7,3 +7,5 @@ stream_update_frequency: 10s
 log_level: warning
 # Set to true if zoraxy is proxied behind Cloudflare
 is_proxied_behind_cloudflare: true
+# IP address display in Recent Blocked Connections: masked (default) or full
+blocked_events_ip_mode: masked

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/config"
 	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/decisions"
 	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/dynamiccapture"
+	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/events"
 	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/info"
 	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/metrics"
 	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/utils"
@@ -140,6 +141,7 @@ func main() {
 	// errGroup and context for plugin goroutines
 	g, ctx := errgroup.WithContext(context.Background())
 	decisionCache := decisions.NewCache()
+	blockedEvents := events.NewBlockedEvents(events.DefaultCapacity)
 
 	// initialize metrics and register custom and CrowdSec metrics
 	metricsHandler := metrics.NewMetricsHandler(logger)
@@ -159,13 +161,13 @@ func main() {
 		We will also print the request information to the console for debugging purposes.
 	*/
 	pathRouter.RegisterDynamicSniffHandler("/d_sniff", http.DefaultServeMux, func(dsfr *plugin.DynamicSniffForwardRequest) plugin.SniffResult {
-		return dynamiccapture.SniffHandler(logger, metricsHandler, pluginConfig, dsfr, decisionCache)
+		return dynamiccapture.SniffHandler(logger, metricsHandler, blockedEvents, pluginConfig, dsfr, decisionCache)
 	})
 	pathRouter.RegisterDynamicCaptureHandle(info.DYNAMIC_CAPTURE_INGRESS, http.DefaultServeMux, func(w http.ResponseWriter, r *http.Request) {
 		dynamiccapture.CaptureHandler(logger, w, r)
 	})
 
-	web.InitWebServer(logger, g, ctx, runtimeCfg.Port, configStatus)
+	web.InitWebServer(logger, g, ctx, runtimeCfg.Port, configStatus, blockedEvents)
 
 	// Handle signals
 	utils.StartSignalHandler(logger, g, ctx)

--- a/main.go
+++ b/main.go
@@ -141,7 +141,7 @@ func main() {
 	// errGroup and context for plugin goroutines
 	g, ctx := errgroup.WithContext(context.Background())
 	decisionCache := decisions.NewCache()
-	blockedEvents := events.NewBlockedEvents(events.DefaultCapacity)
+	blockedEvents := events.NewBlockedEvents(events.DefaultCapacity, pluginConfig.BlockedEventsIPMode)
 
 	// initialize metrics and register custom and CrowdSec metrics
 	metricsHandler := metrics.NewMetricsHandler(logger)

--- a/mod/config/config.go
+++ b/mod/config/config.go
@@ -13,6 +13,7 @@ import (
 )
 
 const DefaultStreamUpdateFrequency = "10s"
+const DefaultBlockedEventsIPMode = "masked"
 const PlaceholderAPIKey = "<CROWDSEC_BOUNCER_API_KEY>"
 
 var ErrConfigCreated = errors.New("config file created")
@@ -26,6 +27,8 @@ stream_update_frequency: 10s
 log_level: warning
 # Set to true if zoraxy is proxied behind Cloudflare
 is_proxied_behind_cloudflare: true
+# IP address display in Recent Blocked Connections: masked (default) or full
+blocked_events_ip_mode: masked
 `
 
 type PluginConfig struct {
@@ -34,6 +37,7 @@ type PluginConfig struct {
 	StreamUpdateFrequency     string `yaml:"stream_update_frequency"`
 	LogLevelString            string `yaml:"log_level"`
 	IsProxiedBehindCloudflare bool   `yaml:"is_proxied_behind_cloudflare"`
+	BlockedEventsIPMode       string `yaml:"blocked_events_ip_mode"`
 
 	LogLevel logrus.Level `yaml:"-"`
 }
@@ -69,6 +73,14 @@ func (p *PluginConfig) PostProcess() error {
 
 	if p.StreamUpdateFrequency == "" {
 		p.StreamUpdateFrequency = DefaultStreamUpdateFrequency
+	}
+
+	p.BlockedEventsIPMode = strings.ToLower(strings.TrimSpace(p.BlockedEventsIPMode))
+	if p.BlockedEventsIPMode == "" {
+		p.BlockedEventsIPMode = DefaultBlockedEventsIPMode
+	}
+	if p.BlockedEventsIPMode != "masked" && p.BlockedEventsIPMode != "full" {
+		return fmt.Errorf("invalid blocked_events_ip_mode %q: must be masked or full", p.BlockedEventsIPMode)
 	}
 	return nil
 }

--- a/mod/config/config_test.go
+++ b/mod/config/config_test.go
@@ -16,6 +16,26 @@ func TestPostProcessDefaultsStreamUpdateFrequency(t *testing.T) {
 	if pluginConfig.StreamUpdateFrequency != DefaultStreamUpdateFrequency {
 		t.Fatalf("StreamUpdateFrequency = %q, want %q", pluginConfig.StreamUpdateFrequency, DefaultStreamUpdateFrequency)
 	}
+	if pluginConfig.BlockedEventsIPMode != DefaultBlockedEventsIPMode {
+		t.Fatalf("BlockedEventsIPMode = %q, want %q", pluginConfig.BlockedEventsIPMode, DefaultBlockedEventsIPMode)
+	}
+}
+
+func TestPostProcessAcceptsAndRejectsBlockedEventsIPModes(t *testing.T) {
+	for _, test := range []struct {
+		mode    string
+		wantErr bool
+	}{
+		{mode: "full"},
+		{mode: "MASKED"},
+		{mode: "invalid", wantErr: true},
+	} {
+		config := PluginConfig{LogLevelString: "warning", BlockedEventsIPMode: test.mode}
+		err := config.PostProcess()
+		if (err != nil) != test.wantErr {
+			t.Fatalf("PostProcess(%q) error = %v, wantErr %v", test.mode, err, test.wantErr)
+		}
+	}
 }
 
 func TestLoadConfigCreatesDefaultOnMissingFile(t *testing.T) {

--- a/mod/dynamiccapture/sniff.go
+++ b/mod/dynamiccapture/sniff.go
@@ -3,6 +3,7 @@ package dynamiccapture
 import (
 	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/config"
 	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/decisions"
+	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/events"
 	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/metrics"
 	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/utils"
 	plugin "github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/zoraxy_plugin"
@@ -13,7 +14,7 @@ import (
 // It is called for each request
 //
 // TODO: if/when we support captchas, we should maybe add a header to the request, or something
-func SniffHandler(logger *logrus.Logger, metricsHandler *metrics.MetricsHandler, config *config.PluginConfig, dsfr *plugin.DynamicSniffForwardRequest, decisions *decisions.Cache) plugin.SniffResult {
+func SniffHandler(logger *logrus.Logger, metricsHandler *metrics.MetricsHandler, blockedEvents *events.BlockedEvents, config *config.PluginConfig, dsfr *plugin.DynamicSniffForwardRequest, decisions *decisions.Cache) plugin.SniffResult {
 	defer metricsHandler.MarkRequestProcessed(dsfr.Hostname)
 
 	// Look up the request IP in the local decision cache.
@@ -33,5 +34,6 @@ func SniffHandler(logger *logrus.Logger, metricsHandler *metrics.MetricsHandler,
 	// to the capture handler, which returns a forbidden response.
 	logger.Debugf("Decision found for IP: %s", ip)
 	metricsHandler.MarkRequestDropped(dsfr.Hostname, decision)
+	blockedEvents.Record(dsfr, ip, decision)
 	return plugin.SniffResultAccept // Accept the request to be handled by the Capture handler
 }

--- a/mod/events/blocked.go
+++ b/mod/events/blocked.go
@@ -11,14 +11,18 @@ import (
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 )
 
-const DefaultCapacity = 200
+const (
+	DefaultCapacity = 200
+	IPModeMasked    = "masked"
+	IPModeFull      = "full"
+)
 
-// BlockedEvent deliberately excludes headers, request bodies, query strings,
-// and the full client address. Those can contain credentials or other secrets.
+// BlockedEvent deliberately excludes headers, request bodies, and query strings,
+// which can contain credentials or other secrets.
 type BlockedEvent struct {
 	Timestamp     time.Time `json:"timestamp"`
 	Hostname      string    `json:"hostname"`
-	ClientNetwork string    `json:"clientNetwork"`
+	ClientAddress string    `json:"clientAddress"`
 	Method        string    `json:"method"`
 	Path          string    `json:"path"`
 	Origin        string    `json:"origin"`
@@ -32,14 +36,18 @@ type BlockedEvent struct {
 type BlockedEvents struct {
 	mu       sync.RWMutex
 	capacity int
+	ipMode   string
 	events   []BlockedEvent
 }
 
-func NewBlockedEvents(capacity int) *BlockedEvents {
+func NewBlockedEvents(capacity int, ipMode string) *BlockedEvents {
 	if capacity <= 0 {
 		capacity = DefaultCapacity
 	}
-	return &BlockedEvents{capacity: capacity, events: make([]BlockedEvent, 0, capacity)}
+	if ipMode != IPModeFull {
+		ipMode = IPModeMasked
+	}
+	return &BlockedEvents{capacity: capacity, ipMode: ipMode, events: make([]BlockedEvent, 0, capacity)}
 }
 
 func (b *BlockedEvents) Record(request *zoraxy_plugin.DynamicSniffForwardRequest, clientIP string, decision *models.Decision) {
@@ -50,7 +58,7 @@ func (b *BlockedEvents) Record(request *zoraxy_plugin.DynamicSniffForwardRequest
 	event := BlockedEvent{
 		Timestamp:     time.Now().UTC(),
 		Hostname:      request.Hostname,
-		ClientNetwork: anonymizeIP(clientIP),
+		ClientAddress: formatClientIP(clientIP, b.ipMode),
 		Method:        request.Method,
 		Path:          safePath(request.RequestURI),
 		Origin:        dereference(decision.Origin),
@@ -85,10 +93,13 @@ func dereference(value *string) string {
 	return *value
 }
 
-func anonymizeIP(value string) string {
+func formatClientIP(value, mode string) string {
 	address, err := netip.ParseAddr(value)
 	if err != nil {
 		return "unknown"
+	}
+	if mode == IPModeFull {
+		return address.String()
 	}
 	if address.Is4() {
 		return netip.PrefixFrom(address, 24).Masked().String()

--- a/mod/events/blocked.go
+++ b/mod/events/blocked.go
@@ -1,0 +1,105 @@
+// Package events keeps a small, privacy-conscious history for the plugin UI.
+package events
+
+import (
+	"net/netip"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/zoraxy_plugin"
+	"github.com/crowdsecurity/crowdsec/pkg/models"
+)
+
+const DefaultCapacity = 200
+
+// BlockedEvent deliberately excludes headers, request bodies, query strings,
+// and the full client address. Those can contain credentials or other secrets.
+type BlockedEvent struct {
+	Timestamp     time.Time `json:"timestamp"`
+	Hostname      string    `json:"hostname"`
+	ClientNetwork string    `json:"clientNetwork"`
+	Method        string    `json:"method"`
+	Path          string    `json:"path"`
+	Origin        string    `json:"origin"`
+	Scenario      string    `json:"scenario"`
+	DecisionType  string    `json:"decisionType"`
+	Scope         string    `json:"scope"`
+	Until         string    `json:"until,omitempty"`
+}
+
+// BlockedEvents is an in-memory, bounded newest-first event store.
+type BlockedEvents struct {
+	mu       sync.RWMutex
+	capacity int
+	events   []BlockedEvent
+}
+
+func NewBlockedEvents(capacity int) *BlockedEvents {
+	if capacity <= 0 {
+		capacity = DefaultCapacity
+	}
+	return &BlockedEvents{capacity: capacity, events: make([]BlockedEvent, 0, capacity)}
+}
+
+func (b *BlockedEvents) Record(request *zoraxy_plugin.DynamicSniffForwardRequest, clientIP string, decision *models.Decision) {
+	if b == nil || request == nil || decision == nil {
+		return
+	}
+
+	event := BlockedEvent{
+		Timestamp:     time.Now().UTC(),
+		Hostname:      request.Hostname,
+		ClientNetwork: anonymizeIP(clientIP),
+		Method:        request.Method,
+		Path:          safePath(request.RequestURI),
+		Origin:        dereference(decision.Origin),
+		Scenario:      dereference(decision.Scenario),
+		DecisionType:  dereference(decision.Type),
+		Scope:         dereference(decision.Scope),
+		Until:         decision.Until,
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.events) < b.capacity {
+		b.events = append(b.events, BlockedEvent{})
+	}
+	copy(b.events[1:], b.events[:len(b.events)-1])
+	b.events[0] = event
+}
+
+func (b *BlockedEvents) Snapshot() []BlockedEvent {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	result := make([]BlockedEvent, len(b.events))
+	copy(result, b.events)
+	return result
+}
+
+func dereference(value *string) string {
+	if value == nil {
+		return "unknown"
+	}
+	return *value
+}
+
+func anonymizeIP(value string) string {
+	address, err := netip.ParseAddr(value)
+	if err != nil {
+		return "unknown"
+	}
+	if address.Is4() {
+		return netip.PrefixFrom(address, 24).Masked().String()
+	}
+	return netip.PrefixFrom(address, 64).Masked().String()
+}
+
+func safePath(requestURI string) string {
+	parsed, err := url.ParseRequestURI(requestURI)
+	if err != nil || parsed.EscapedPath() == "" {
+		return "/"
+	}
+	return parsed.EscapedPath()
+}

--- a/mod/events/blocked_test.go
+++ b/mod/events/blocked_test.go
@@ -10,7 +10,7 @@ import (
 func stringPtr(value string) *string { return &value }
 
 func TestBlockedEventsRetainsSafeNewestEvents(t *testing.T) {
-	store := NewBlockedEvents(2)
+	store := NewBlockedEvents(2, IPModeMasked)
 	decision := &models.Decision{
 		Origin:   stringPtr("crowdsec"),
 		Scenario: stringPtr("crowdsecurity/http-probing"),
@@ -29,14 +29,23 @@ func TestBlockedEventsRetainsSafeNewestEvents(t *testing.T) {
 	if snapshot[0].Hostname != "three.example" || snapshot[1].Hostname != "two.example" {
 		t.Fatalf("events are not newest-first: %#v", snapshot)
 	}
-	if snapshot[1].ClientNetwork != "2001:db8:abcd:1234::/64" {
-		t.Fatalf("unexpected IPv6 mask: %q", snapshot[1].ClientNetwork)
+	if snapshot[1].ClientAddress != "2001:db8:abcd:1234::/64" {
+		t.Fatalf("unexpected IPv6 mask: %q", snapshot[1].ClientAddress)
 	}
-	if snapshot[0].ClientNetwork != "unknown" {
-		t.Fatalf("unexpected invalid IP value: %q", snapshot[0].ClientNetwork)
+	if snapshot[0].ClientAddress != "unknown" {
+		t.Fatalf("unexpected invalid IP value: %q", snapshot[0].ClientAddress)
 	}
 	if snapshot[1].Path != "/second" {
 		t.Fatalf("unexpected path: %q", snapshot[1].Path)
+	}
+}
+
+func TestBlockedEventsCanStoreFullClientIP(t *testing.T) {
+	store := NewBlockedEvents(1, IPModeFull)
+	store.Record(&zoraxy_plugin.DynamicSniffForwardRequest{}, "192.0.2.42", &models.Decision{})
+
+	if got := store.Snapshot()[0].ClientAddress; got != "192.0.2.42" {
+		t.Fatalf("full IP mode stored %q, want exact IP", got)
 	}
 }
 

--- a/mod/events/blocked_test.go
+++ b/mod/events/blocked_test.go
@@ -1,0 +1,47 @@
+package events
+
+import (
+	"testing"
+
+	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/zoraxy_plugin"
+	"github.com/crowdsecurity/crowdsec/pkg/models"
+)
+
+func stringPtr(value string) *string { return &value }
+
+func TestBlockedEventsRetainsSafeNewestEvents(t *testing.T) {
+	store := NewBlockedEvents(2)
+	decision := &models.Decision{
+		Origin:   stringPtr("crowdsec"),
+		Scenario: stringPtr("crowdsecurity/http-probing"),
+		Type:     stringPtr("ban"),
+		Scope:    stringPtr("ip"),
+	}
+
+	store.Record(&zoraxy_plugin.DynamicSniffForwardRequest{Hostname: "one.example", Method: "GET", RequestURI: "/first?token=secret"}, "192.0.2.42", decision)
+	store.Record(&zoraxy_plugin.DynamicSniffForwardRequest{Hostname: "two.example", Method: "POST", RequestURI: "/second"}, "2001:db8:abcd:1234::1", decision)
+	store.Record(&zoraxy_plugin.DynamicSniffForwardRequest{Hostname: "three.example", Method: "GET", RequestURI: "/third"}, "invalid", decision)
+
+	snapshot := store.Snapshot()
+	if len(snapshot) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(snapshot))
+	}
+	if snapshot[0].Hostname != "three.example" || snapshot[1].Hostname != "two.example" {
+		t.Fatalf("events are not newest-first: %#v", snapshot)
+	}
+	if snapshot[1].ClientNetwork != "2001:db8:abcd:1234::/64" {
+		t.Fatalf("unexpected IPv6 mask: %q", snapshot[1].ClientNetwork)
+	}
+	if snapshot[0].ClientNetwork != "unknown" {
+		t.Fatalf("unexpected invalid IP value: %q", snapshot[0].ClientNetwork)
+	}
+	if snapshot[1].Path != "/second" {
+		t.Fatalf("unexpected path: %q", snapshot[1].Path)
+	}
+}
+
+func TestSafePathDropsQueryString(t *testing.T) {
+	if got := safePath("/login?password=secret"); got != "/login" {
+		t.Fatalf("safePath() = %q, want /login", got)
+	}
+}

--- a/mod/web/web.go
+++ b/mod/web/web.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/events"
 	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/info"
 	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/metrics"
 	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/zoraxy_plugin"
@@ -36,10 +37,6 @@ type MetricsResponse struct {
 	Error             string             `json:"error,omitempty"`
 }
 
-type HeadersResponse struct {
-	Headers map[string][]string `json:"headers"`
-}
-
 type ConfigStatusResponse struct {
 	Onboarding      bool     `json:"onboarding"`
 	BlockingEnabled bool     `json:"blockingEnabled"`
@@ -51,6 +48,8 @@ var runtimeConfigStatus = ConfigStatusResponse{
 	Onboarding:      false,
 	BlockingEnabled: true,
 }
+
+var blockedEventsStore = events.NewBlockedEvents(events.DefaultCapacity)
 
 // API handlers
 func apiVersionHandler(w http.ResponseWriter, r *http.Request) {
@@ -142,19 +141,9 @@ func apiMetricsHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(response)
 }
 
-func apiHeadersHandler(w http.ResponseWriter, r *http.Request) {
+func apiBlockedEventsHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-
-	response := HeadersResponse{
-		Headers: make(map[string][]string),
-	}
-
-	// Copy all headers
-	for name, values := range r.Header {
-		response.Headers[name] = values
-	}
-
-	json.NewEncoder(w).Encode(response)
+	json.NewEncoder(w).Encode(blockedEventsStore.Snapshot())
 }
 
 func apiConfigStatusHandler(w http.ResponseWriter, r *http.Request) {
@@ -254,8 +243,11 @@ func versionCheck() (string, error) {
 // Also sets up a shutdown handler for graceful shutdown.
 //
 // Runs everything on the default serve mux.
-func InitWebServer(logger *logrus.Logger, g *errgroup.Group, ctx context.Context, port int, configStatus ConfigStatusResponse) {
+func InitWebServer(logger *logrus.Logger, g *errgroup.Group, ctx context.Context, port int, configStatus ConfigStatusResponse, blockedEvents *events.BlockedEvents) {
 	runtimeConfigStatus = configStatus
+	if blockedEvents != nil {
+		blockedEventsStore = blockedEvents
+	}
 
 	mux := http.DefaultServeMux
 
@@ -266,7 +258,7 @@ func InitWebServer(logger *logrus.Logger, g *errgroup.Group, ctx context.Context
 	// Add API endpoints
 	mux.HandleFunc(info.UI_PATH+"api/version", apiVersionHandler)
 	mux.HandleFunc(info.UI_PATH+"api/metrics", apiMetricsHandler)
-	mux.HandleFunc(info.UI_PATH+"api/headers", apiHeadersHandler)
+	mux.HandleFunc(info.UI_PATH+"api/blocked-events", apiBlockedEventsHandler)
 	mux.HandleFunc(info.UI_PATH+"api/config-status", apiConfigStatusHandler)
 
 	serverAddr := fmt.Sprintf("127.0.0.1:%d", port)

--- a/mod/web/web.go
+++ b/mod/web/web.go
@@ -49,7 +49,7 @@ var runtimeConfigStatus = ConfigStatusResponse{
 	BlockingEnabled: true,
 }
 
-var blockedEventsStore = events.NewBlockedEvents(events.DefaultCapacity)
+var blockedEventsStore = events.NewBlockedEvents(events.DefaultCapacity, events.IPModeMasked)
 
 // API handlers
 func apiVersionHandler(w http.ResponseWriter, r *http.Request) {

--- a/mod/web/web_test.go
+++ b/mod/web/web_test.go
@@ -1,0 +1,44 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/events"
+	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/zoraxy_plugin"
+	"github.com/crowdsecurity/crowdsec/pkg/models"
+)
+
+func webStringPtr(value string) *string { return &value }
+
+func TestAPIBlockedEventsHandlerReturnsSanitizedEvents(t *testing.T) {
+	store := events.NewBlockedEvents(1)
+	store.Record(&zoraxy_plugin.DynamicSniffForwardRequest{
+		Hostname:   "service.example",
+		Method:     http.MethodPost,
+		RequestURI: "/login?token=secret",
+	}, "198.51.100.24", &models.Decision{
+		Origin:   webStringPtr("crowdsec"),
+		Scenario: webStringPtr("crowdsecurity/http-probing"),
+		Type:     webStringPtr("ban"),
+		Scope:    webStringPtr("ip"),
+	})
+	blockedEventsStore = store
+
+	response := httptest.NewRecorder()
+	apiBlockedEventsHandler(response, httptest.NewRequest(http.MethodGet, "/api/blocked-events", nil))
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusOK)
+	}
+
+	var got []events.BlockedEvent
+	if err := json.NewDecoder(response.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(got) != 1 || got[0].ClientNetwork != "198.51.100.0/24" || got[0].Path != "/login" {
+		t.Fatalf("unexpected events: %#v", got)
+	}
+}

--- a/mod/web/web_test.go
+++ b/mod/web/web_test.go
@@ -14,7 +14,7 @@ import (
 func webStringPtr(value string) *string { return &value }
 
 func TestAPIBlockedEventsHandlerReturnsSanitizedEvents(t *testing.T) {
-	store := events.NewBlockedEvents(1)
+	store := events.NewBlockedEvents(1, events.IPModeMasked)
 	store.Record(&zoraxy_plugin.DynamicSniffForwardRequest{
 		Hostname:   "service.example",
 		Method:     http.MethodPost,
@@ -38,7 +38,7 @@ func TestAPIBlockedEventsHandlerReturnsSanitizedEvents(t *testing.T) {
 	if err := json.NewDecoder(response.Body).Decode(&got); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if len(got) != 1 || got[0].ClientNetwork != "198.51.100.0/24" || got[0].Path != "/login" {
+	if len(got) != 1 || got[0].ClientAddress != "198.51.100.0/24" || got[0].Path != "/login" {
 		t.Fatalf("unexpected events: %#v", got)
 	}
 }

--- a/mod/web/www/index.html
+++ b/mod/web/www/index.html
@@ -48,7 +48,7 @@
 
 	<div class="ui basic segment">
 		<h2>Recent Blocked Connections</h2>
-		<p class="event-note">The latest 200 blocked requests from this plugin session. Client addresses are masked; headers, query strings, and bodies are never stored.</p>
+		<p class="event-note">The latest 200 blocked requests from this plugin session. Headers, query strings, and bodies are never stored. Client-address display follows <code>blocked_events_ip_mode</code>.</p>
 		<div id="blocked-events-container">Loading...</div>
 	</div>
 
@@ -223,14 +223,14 @@
 					const rows = data.map(event => `<tr>
 						<td>${escapeHtml(new Date(event.timestamp).toLocaleString())}</td>
 						<td>${escapeHtml(event.hostname)}</td>
-						<td>${escapeHtml(event.clientNetwork)}</td>
+						<td>${escapeHtml(event.clientAddress)}</td>
 						<td>${escapeHtml(event.method)} ${escapeHtml(event.path)}</td>
 						<td>${escapeHtml(event.decisionType)}</td>
 						<td>${escapeHtml(event.origin)}</td>
 						<td>${escapeHtml(event.scenario)}</td>
 					</tr>`).join('');
 					container.innerHTML = `<div class="events-table-wrapper"><table class="ui compact celled table events-table">
-						<thead><tr><th>Time</th><th>Hostname</th><th>Client network</th><th>Request</th><th>Action</th><th>Origin</th><th>Scenario</th></tr></thead>
+						<thead><tr><th>Time</th><th>Hostname</th><th>Client address</th><th>Request</th><th>Action</th><th>Origin</th><th>Scenario</th></tr></thead>
 						<tbody>${rows}</tbody>
 					</table></div>`;
 			} catch (error) {

--- a/mod/web/www/index.html
+++ b/mod/web/www/index.html
@@ -47,8 +47,9 @@
 	<div class="ui divider"></div>
 
 	<div class="ui basic segment">
-    	<h2>[Received Headers]</h2>
-    	<pre id="headers-display">Loading...</pre>
+		<h2>Recent Blocked Connections</h2>
+		<p class="event-note">The latest 200 blocked requests from this plugin session. Client addresses are masked; headers, query strings, and bodies are never stored.</p>
+		<div id="blocked-events-container">Loading...</div>
 	</div>
 
 </div>
@@ -67,16 +68,20 @@
         function wrapError(message) {
             return `<span class="error">Error: ${escapeHtml(message)}</span>`;
         }
+
+		async function requestJSON(url) {
+			const response = await fetch(url);
+			if (!response.ok) {
+				throw new Error(`${response.status} ${response.statusText}`);
+			}
+			return response.json();
+		}
         
         // API functions
         async function fetchVersion() {
 			const versionInfo = document.getElementById('version-info');
-
-			$.ajax({
-				url: './api/version',
-				method: 'GET',
-				dataType: 'json',
-				success: function(data) {
+			try {
+				const data = await requestJSON('./api/version');
 					let versionText = escapeHtml(data.version);
 
 					if (data.checkError) {
@@ -87,21 +92,16 @@
 						versionText += ` <a href="${escapeHtml(data.updateLink)}">(update available)</a>`;
 					}
 					versionInfo.innerHTML = versionText;
-				},
-				error: function(xhr, status, error) {
-					versionInfo.innerHTML = wrapError(`Failed to fetch version: ${xhr.status} ${xhr.statusText}`);
-				}
-			});
+			} catch (error) {
+				versionInfo.innerHTML = wrapError(`Failed to fetch version: ${error.message}`);
+			}
         }
         
         async function fetchMetrics() {
 			metricsDashboard = document.getElementById('metrics-dashboard');
 
-			$.ajax({
-				url: './api/metrics',
-				method: 'GET',
-				dataType: 'json',
-				success: function(data) {
+			try {
+				const data = await requestJSON('./api/metrics');
 					// If there's an error, show it
 					if (data.error) {
 						metricsDashboard.innerHTML = `
@@ -110,7 +110,7 @@
 								<div class="metric-description error">${wrapError(data.error)}</div>
 							</div>
 						`;
-						return;
+					return;
 					}
 
 					// Build up the HTML for metrics
@@ -169,26 +169,21 @@
 					
 					// Render the metrics dashboard
 					metricsDashboard.innerHTML = html;
-				},
-				error: function(xhr, status, error) {
-					metricsDashboard.innerHTML = `
-						<div class="ui message error three columns">
-							<div class="metric-title">Error</div>
-							<div class="metric-description error">${wrapError(`Failed to fetch metrics: ${xhr.status} ${xhr.statusText}`)}</div>
-						</div>
-					`;
-				}
-			});
+			} catch (error) {
+				metricsDashboard.innerHTML = `
+					<div class="ui message error three columns">
+						<div class="metric-title">Error</div>
+						<div class="metric-description error">${wrapError(`Failed to fetch metrics: ${error.message}`)}</div>
+					</div>
+				`;
+			}
         }
 
 		async function fetchConfigStatus() {
 			const statusContainer = document.getElementById('config-status-container');
 
-			$.ajax({
-				url: './api/config-status',
-				method: 'GET',
-				dataType: 'json',
-				success: function(data) {
+			try {
+				const data = await requestJSON('./api/config-status');
 					if (!data.onboarding) {
 						statusContainer.innerHTML = '';
 						return;
@@ -206,53 +201,50 @@
 							<p>Blocking is currently disabled until configuration is completed and the plugin is restarted.</p>
 						</div>
 					`;
-				},
-				error: function(xhr) {
+			} catch (error) {
 					statusContainer.innerHTML = `
 						<div class="ui message error">
 							<div class="header">Unable to load configuration status</div>
- 							<p>${wrapError('Failed to fetch config status: ' + xhr.status + ' ' + xhr.statusText)}</p>						</div>
+							<p>${wrapError('Failed to fetch config status: ' + error.message)}</p>						</div>
 					`;
-				}
-			});
+			}
 		}
         
-        async function fetchHeaders() {
-			headersDisplay = document.getElementById('headers-display');
+		async function fetchBlockedEvents() {
+			const container = document.getElementById('blocked-events-container');
 
-			$.ajax({
-				url: './api/headers',
-				method: 'GET',
-				dataType: 'json',
-				success: function(data) {
-					let headersText = '';
-					const sortedHeaders = Object.keys(data.headers).sort();
-
-					for (const headerName of sortedHeaders) {
-						const values = data.headers[headerName];
-						for (const value of values) {
-							headersText += `${headerName}: ${escapeHtml(value)}\n`;
-						}
+			try {
+				const data = await requestJSON('./api/blocked-events');
+					if (!Array.isArray(data) || data.length === 0) {
+						container.innerHTML = '<div class="ui message">No blocked connections recorded in this plugin session.</div>';
+						return;
 					}
 
-					if (headersText === '') {
-						headersText = 'No headers received yet.';
-					}
-					headersDisplay.textContent = headersText;
-				},
-				error: function(xhr, status, error) {
-					headersDisplay.innerHTML = wrapError(`Failed to fetch headers: ${xhr.status} ${xhr.statusText}`);
-				}
-			});
-        }
+					const rows = data.map(event => `<tr>
+						<td>${escapeHtml(new Date(event.timestamp).toLocaleString())}</td>
+						<td>${escapeHtml(event.hostname)}</td>
+						<td>${escapeHtml(event.clientNetwork)}</td>
+						<td>${escapeHtml(event.method)} ${escapeHtml(event.path)}</td>
+						<td>${escapeHtml(event.decisionType)}</td>
+						<td>${escapeHtml(event.origin)}</td>
+						<td>${escapeHtml(event.scenario)}</td>
+					</tr>`).join('');
+					container.innerHTML = `<div class="events-table-wrapper"><table class="ui compact celled table events-table">
+						<thead><tr><th>Time</th><th>Hostname</th><th>Client network</th><th>Request</th><th>Action</th><th>Origin</th><th>Scenario</th></tr></thead>
+						<tbody>${rows}</tbody>
+					</table></div>`;
+			} catch (error) {
+				container.innerHTML = `<div class="ui message error">${wrapError(`Failed to fetch blocked connections: ${error.message}`)}</div>`;
+			}
+		}
         
         // Refresh functions
         async function refreshMetrics() {
             if (refreshing) return;
             
             refreshing = true;
-			$("#refresh-btn").addClass("loading")
             const button = document.getElementById('refresh-btn');
+			button.classList.add('loading');
             const originalText = button.innerHTML;
 			button.disabled = true;
 
@@ -263,7 +255,7 @@
                 setTimeout(() => {
                     button.disabled = false;
                     refreshing = false;
-					$("#refresh-btn").removeClass("loading")
+					button.classList.remove('loading');
                 }, 1000);
                 
             } catch (error) {
@@ -271,7 +263,7 @@
                 setTimeout(() => {
                     button.disabled = false;
                     refreshing = false;
-					$("#refresh-btn").removeClass("loading")
+					button.classList.remove('loading');
                 }, 2000);
             }
         }
@@ -280,8 +272,8 @@
             await Promise.all([
                 fetchVersion(),
 				fetchConfigStatus(),
-                fetchMetrics(),
-                fetchHeaders()
+				fetchMetrics(),
+				fetchBlockedEvents()
             ]);
         }
         

--- a/mod/web/www/styles.css
+++ b/mod/web/www/styles.css
@@ -19,6 +19,19 @@ pre {
     word-wrap: break-word;
 }
 
+.event-note {
+    color: var(--text_color);
+    opacity: 0.8;
+}
+
+.events-table-wrapper {
+    overflow-x: auto;
+}
+
+.events-table {
+    min-width: 900px;
+}
+
 /* Tooltip styling */
 .tooltip {
     cursor: help;

--- a/tools/standalone_ui.go
+++ b/tools/standalone_ui.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/config"
+	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/events"
 	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/utils"
 	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/web"
 	"github.com/sirupsen/logrus"
@@ -39,7 +40,7 @@ func main() {
 	web.InitWebServer(logger, g, ctx, PORT, web.ConfigStatusResponse{
 		Onboarding:      false,
 		BlockingEnabled: true,
-	})
+	}, events.NewBlockedEvents(events.DefaultCapacity))
 
 	// Handle signals
 	utils.StartSignalHandler(logrus.StandardLogger(), g, ctx)

--- a/tools/standalone_ui.go
+++ b/tools/standalone_ui.go
@@ -40,7 +40,7 @@ func main() {
 	web.InitWebServer(logger, g, ctx, PORT, web.ConfigStatusResponse{
 		Onboarding:      false,
 		BlockingEnabled: true,
-	}, events.NewBlockedEvents(events.DefaultCapacity))
+	}, events.NewBlockedEvents(events.DefaultCapacity, events.IPModeMasked))
 
 	// Handle signals
 	utils.StartSignalHandler(logrus.StandardLogger(), g, ctx)


### PR DESCRIPTION
Closes #24

## What changed
- Replaces the UI request-header dump with a bounded table of the latest 200 blocked connections from the current plugin session.
- Stores hostname, method, path without query string, and CrowdSec decision metadata; request headers and bodies are never retained.
- Adds `blocked_events_ip_mode`: `masked` is the default, while `full` enables exact client IP display for trusted administration UIs.
- Replaces the UI jQuery request dependency with native `fetch`, so the standalone UI works without Zoraxy-hosted assets.

## Validation
- `go test ./...`
- `git diff --check`
- Standalone UI smoke test: page loads without console warnings/errors, renders the blocked-connections empty state, and refresh remains usable.
- Production verification on a Zoraxy host: a temporary CrowdSec ban generated real blocked-connection events; the stored data had the expected hostname, method/path, decision metadata, and masked client address. The decision was deleted after the test.