### PR TITLE
feat(metrics): add Prometheus metrics and rolling block aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ agent_url: http://127.0.0.1:8080 # for example
 stream_update_frequency: 10s # How often to retrieve decision deltas from CrowdSec
 log_level: warning # Log level for the bouncer, options: trace, debug, info, warning, error
 is_proxied_behind_cloudflare: true # Set to true if your zoraxy instance is proxied behind Cloudflare
+# Optional dedicated listener for Prometheus, e.g. :2112
+prometheus_listen_addr: ""
 ```
 
 You can get the API key by running the following command:
@@ -135,7 +137,7 @@ In it, you can view some basic information about the bouncer, such as the number
 
 The plugin exposes its Prometheus metrics at `/metrics` in the standard Prometheus text format. This includes `zoraxy_bouncer_blocked_requests` and `zoraxy_bouncer_processed_requests`, labelled by hostname (and decision origin for blocked requests).
 
-The plugin server listens on loopback. If you make this endpoint reachable through Zoraxy or another proxy for Prometheus, keep it on a trusted network and apply access controls; metrics may reveal service names and traffic volumes.
+Set `prometheus_listen_addr` (for example, `:2112`) to also start a dedicated scrape listener. It is disabled by default. Bind or publish this port only on a trusted network and apply access controls; metrics may reveal service names and traffic volumes.
 
 ### Onboarding Mode
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ The web UI is available from the Zoraxy web interface in the "Plugins" section.
 
 In it, you can view some basic information about the bouncer, such as the number of requests processed and dropped by the bouncer for each hostname.
 
+## Prometheus
+
+The plugin exposes its Prometheus metrics at `/metrics` in the standard Prometheus text format. This includes `zoraxy_bouncer_blocked_requests` and `zoraxy_bouncer_processed_requests`, labelled by hostname (and decision origin for blocked requests).
+
+The plugin server listens on loopback. If you make this endpoint reachable through Zoraxy or another proxy for Prometheus, keep it on a trusted network and apply access controls; metrics may reveal service names and traffic volumes.
+
 ### Onboarding Mode
 
 If `api_key` is not set yet, the plugin starts in onboarding mode. In this state,

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ agent_url: http://127.0.0.1:8080 # for example
 stream_update_frequency: 10s # How often to retrieve decision deltas from CrowdSec
 log_level: warning # Log level for the bouncer, options: trace, debug, info, warning, error
 is_proxied_behind_cloudflare: true # Set to true if your zoraxy instance is proxied behind Cloudflare
+# JSON file for the exact rolling 24-hour blocked-request aggregate
+blocked_requests_aggregation_file: blocked-requests-24h.json
 # Optional dedicated listener for Prometheus, e.g. :2112
 prometheus_listen_addr: ""
 ```
@@ -136,6 +138,8 @@ In it, you can view some basic information about the bouncer, such as the number
 ## Prometheus
 
 The plugin exposes its Prometheus metrics at `/metrics` in the standard Prometheus text format. This includes `zoraxy_bouncer_blocked_requests` and `zoraxy_bouncer_processed_requests`, labelled by hostname (and decision origin for blocked requests).
+
+`zoraxy_bouncer_blocked_requests_24h` is an exact rolling 24-hour count of blocked requests. It is backed by `blocked_requests_aggregation_file` and survives plugin restarts. The JSON file contains only event timestamp, hostname, and CrowdSec decision origin; it deliberately contains no client IP address, request path, headers, or body.
 
 Set `prometheus_listen_addr` (for example, `:2112`) to also start a dedicated scrape listener. It is disabled by default. Bind or publish this port only on a trusted network and apply access controls; metrics may reveal service names and traffic volumes.
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ agent_url: http://127.0.0.1:8080 # for example
 stream_update_frequency: 10s # How often to retrieve decision deltas from CrowdSec
 log_level: warning # Log level for the bouncer, options: trace, debug, info, warning, error
 is_proxied_behind_cloudflare: true # Set to true if your zoraxy instance is proxied behind Cloudflare
-# JSON file for the exact rolling 24-hour blocked-request aggregate
+# JSON file for the 72-hour, per-minute blocked-request aggregate
 blocked_requests_aggregation_file: blocked-requests-24h.json
 # Optional dedicated listener for Prometheus, e.g. :2112
 prometheus_listen_addr: ""
@@ -139,7 +139,7 @@ In it, you can view some basic information about the bouncer, such as the number
 
 The plugin exposes its Prometheus metrics at `/metrics` in the standard Prometheus text format. This includes `zoraxy_bouncer_blocked_requests` and `zoraxy_bouncer_processed_requests`, labelled by hostname (and decision origin for blocked requests).
 
-`zoraxy_bouncer_blocked_requests_24h` is an exact rolling 24-hour count of blocked requests. It is backed by `blocked_requests_aggregation_file` and survives plugin restarts. The JSON file contains only event timestamp, hostname, and CrowdSec decision origin; it deliberately contains no client IP address, request path, headers, or body.
+`zoraxy_bouncer_blocked_requests_24h` is a rolling 24-hour count of blocked requests, calculated from per-minute buckets retained for 72 hours. It survives plugin restarts and has a maximum one-minute boundary variance. The JSON file contains only bucket timestamp, hostname, CrowdSec decision origin, and count; it deliberately contains no client IP address, request path, headers, or body.
 
 Set `prometheus_listen_addr` (for example, `:2112`) to also start a dedicated scrape listener. It is disabled by default. Bind or publish this port only on a trusted network and apply access controls; metrics may reveal service names and traffic volumes.
 

--- a/config.yaml
+++ b/config.yaml
@@ -7,3 +7,5 @@ stream_update_frequency: 10s
 log_level: warning
 # Set to true if zoraxy is proxied behind Cloudflare
 is_proxied_behind_cloudflare: true
+# Optional dedicated Prometheus listener, e.g. :2112. Leave empty to disable.
+prometheus_listen_addr: ""

--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,7 @@ stream_update_frequency: 10s
 log_level: warning
 # Set to true if zoraxy is proxied behind Cloudflare
 is_proxied_behind_cloudflare: true
-# Persisted rolling 24-hour block aggregation (contains only timestamp, hostname and origin)
+# Persisted per-minute block aggregation; retains 72 hours (timestamp, hostname and origin only)
 blocked_requests_aggregation_file: blocked-requests-24h.json
 # Optional dedicated Prometheus listener, e.g. :2112. Leave empty to disable.
 prometheus_listen_addr: ""

--- a/config.yaml
+++ b/config.yaml
@@ -7,5 +7,7 @@ stream_update_frequency: 10s
 log_level: warning
 # Set to true if zoraxy is proxied behind Cloudflare
 is_proxied_behind_cloudflare: true
+# Persisted rolling 24-hour block aggregation (contains only timestamp, hostname and origin)
+blocked_requests_aggregation_file: blocked-requests-24h.json
 # Optional dedicated Prometheus listener, e.g. :2112. Leave empty to disable.
 prometheus_listen_addr: ""

--- a/main.go
+++ b/main.go
@@ -166,6 +166,7 @@ func main() {
 	})
 
 	web.InitWebServer(logger, g, ctx, runtimeCfg.Port, configStatus)
+	web.StartPrometheusServer(logger, g, ctx, pluginConfig.PrometheusListenAddr)
 
 	// Handle signals
 	utils.StartSignalHandler(logger, g, ctx)

--- a/main.go
+++ b/main.go
@@ -142,7 +142,7 @@ func main() {
 	decisionCache := decisions.NewCache()
 
 	// initialize metrics and register custom and CrowdSec metrics
-	metricsHandler := metrics.NewMetricsHandler(logger)
+	metricsHandler := metrics.NewMetricsHandler(logger, pluginConfig.BlockedRequestsAggregationFile)
 	metrics.Map.MustRegisterAll()
 	prometheus.MustRegister(csbouncer.TotalLAPICalls, csbouncer.TotalLAPIError)
 

--- a/mod/config/config.go
+++ b/mod/config/config.go
@@ -27,7 +27,7 @@ stream_update_frequency: 10s
 log_level: warning
 # Set to true if zoraxy is proxied behind Cloudflare
 is_proxied_behind_cloudflare: true
-# Persisted rolling 24-hour block aggregation (contains only timestamp, hostname and origin)
+# Persisted per-minute block aggregation; retains 72 hours (timestamp, hostname and origin only)
 blocked_requests_aggregation_file: blocked-requests-24h.json
 # Optional dedicated Prometheus listener, e.g. :2112. Leave empty to disable.
 prometheus_listen_addr: ""

--- a/mod/config/config.go
+++ b/mod/config/config.go
@@ -26,6 +26,8 @@ stream_update_frequency: 10s
 log_level: warning
 # Set to true if zoraxy is proxied behind Cloudflare
 is_proxied_behind_cloudflare: true
+# Optional dedicated Prometheus listener, e.g. :2112. Leave empty to disable.
+prometheus_listen_addr: ""
 `
 
 type PluginConfig struct {
@@ -34,6 +36,7 @@ type PluginConfig struct {
 	StreamUpdateFrequency     string `yaml:"stream_update_frequency"`
 	LogLevelString            string `yaml:"log_level"`
 	IsProxiedBehindCloudflare bool   `yaml:"is_proxied_behind_cloudflare"`
+	PrometheusListenAddr      string `yaml:"prometheus_listen_addr"`
 
 	LogLevel logrus.Level `yaml:"-"`
 }
@@ -70,6 +73,7 @@ func (p *PluginConfig) PostProcess() error {
 	if p.StreamUpdateFrequency == "" {
 		p.StreamUpdateFrequency = DefaultStreamUpdateFrequency
 	}
+	p.PrometheusListenAddr = strings.TrimSpace(p.PrometheusListenAddr)
 	return nil
 }
 

--- a/mod/config/config.go
+++ b/mod/config/config.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/info"
+	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/metrics"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
@@ -26,17 +27,20 @@ stream_update_frequency: 10s
 log_level: warning
 # Set to true if zoraxy is proxied behind Cloudflare
 is_proxied_behind_cloudflare: true
+# Persisted rolling 24-hour block aggregation (contains only timestamp, hostname and origin)
+blocked_requests_aggregation_file: blocked-requests-24h.json
 # Optional dedicated Prometheus listener, e.g. :2112. Leave empty to disable.
 prometheus_listen_addr: ""
 `
 
 type PluginConfig struct {
-	APIKey                    string `yaml:"api_key"`
-	AgentUrl                  string `yaml:"agent_url"`
-	StreamUpdateFrequency     string `yaml:"stream_update_frequency"`
-	LogLevelString            string `yaml:"log_level"`
-	IsProxiedBehindCloudflare bool   `yaml:"is_proxied_behind_cloudflare"`
-	PrometheusListenAddr      string `yaml:"prometheus_listen_addr"`
+	APIKey                         string `yaml:"api_key"`
+	AgentUrl                       string `yaml:"agent_url"`
+	StreamUpdateFrequency          string `yaml:"stream_update_frequency"`
+	LogLevelString                 string `yaml:"log_level"`
+	IsProxiedBehindCloudflare      bool   `yaml:"is_proxied_behind_cloudflare"`
+	BlockedRequestsAggregationFile string `yaml:"blocked_requests_aggregation_file"`
+	PrometheusListenAddr           string `yaml:"prometheus_listen_addr"`
 
 	LogLevel logrus.Level `yaml:"-"`
 }
@@ -74,6 +78,10 @@ func (p *PluginConfig) PostProcess() error {
 		p.StreamUpdateFrequency = DefaultStreamUpdateFrequency
 	}
 	p.PrometheusListenAddr = strings.TrimSpace(p.PrometheusListenAddr)
+	p.BlockedRequestsAggregationFile = strings.TrimSpace(p.BlockedRequestsAggregationFile)
+	if p.BlockedRequestsAggregationFile == "" {
+		p.BlockedRequestsAggregationFile = metrics.DefaultBlockedRequestsAggregationFile
+	}
 	return nil
 }
 

--- a/mod/config/config_test.go
+++ b/mod/config/config_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/metrics"
 )
 
 func TestPostProcessDefaultsStreamUpdateFrequency(t *testing.T) {
@@ -18,6 +20,9 @@ func TestPostProcessDefaultsStreamUpdateFrequency(t *testing.T) {
 	}
 	if pluginConfig.PrometheusListenAddr != "" {
 		t.Fatalf("PrometheusListenAddr = %q, want empty default", pluginConfig.PrometheusListenAddr)
+	}
+	if pluginConfig.BlockedRequestsAggregationFile != metrics.DefaultBlockedRequestsAggregationFile {
+		t.Fatalf("BlockedRequestsAggregationFile = %q, want %q", pluginConfig.BlockedRequestsAggregationFile, metrics.DefaultBlockedRequestsAggregationFile)
 	}
 }
 

--- a/mod/config/config_test.go
+++ b/mod/config/config_test.go
@@ -16,6 +16,19 @@ func TestPostProcessDefaultsStreamUpdateFrequency(t *testing.T) {
 	if pluginConfig.StreamUpdateFrequency != DefaultStreamUpdateFrequency {
 		t.Fatalf("StreamUpdateFrequency = %q, want %q", pluginConfig.StreamUpdateFrequency, DefaultStreamUpdateFrequency)
 	}
+	if pluginConfig.PrometheusListenAddr != "" {
+		t.Fatalf("PrometheusListenAddr = %q, want empty default", pluginConfig.PrometheusListenAddr)
+	}
+}
+
+func TestPostProcessTrimsPrometheusListenAddress(t *testing.T) {
+	pluginConfig := PluginConfig{LogLevelString: "warning", PrometheusListenAddr: " :2112 "}
+	if err := pluginConfig.PostProcess(); err != nil {
+		t.Fatalf("PostProcess() error = %v", err)
+	}
+	if pluginConfig.PrometheusListenAddr != ":2112" {
+		t.Fatalf("PrometheusListenAddr = %q, want :2112", pluginConfig.PrometheusListenAddr)
+	}
 }
 
 func TestLoadConfigCreatesDefaultOnMissingFile(t *testing.T) {

--- a/mod/metrics/blocked_aggregation.go
+++ b/mod/metrics/blocked_aggregation.go
@@ -45,7 +45,11 @@ type BlockedRequestsAggregator struct {
 }
 
 func NewBlockedRequestsAggregator(path string) (*BlockedRequestsAggregator, error) {
-	a := &BlockedRequestsAggregator{path: path, now: time.Now, buckets: make(map[blockedRequestBucketKey]uint64)}
+	return newBlockedRequestsAggregator(path, time.Now)
+}
+
+func newBlockedRequestsAggregator(path string, now func() time.Time) (*BlockedRequestsAggregator, error) {
+	a := &BlockedRequestsAggregator{path: path, now: now, buckets: make(map[blockedRequestBucketKey]uint64)}
 	if err := a.load(); err != nil {
 		return a, err
 	}

--- a/mod/metrics/blocked_aggregation.go
+++ b/mod/metrics/blocked_aggregation.go
@@ -11,12 +11,17 @@ import (
 	"time"
 )
 
-const BlockedRequestsAggregationWindow = 24 * time.Hour
+const (
+	BlockedRequestsAggregationWindow = 72 * time.Hour
+	BlockedRequestsMetricWindow      = 24 * time.Hour
+	BlockedRequestsBucketDuration    = time.Minute
+)
 
-type BlockedRequestEvent struct {
+type BlockedRequestBucket struct {
 	Timestamp time.Time `json:"timestamp"`
 	Hostname  string    `json:"hostname"`
 	Origin    string    `json:"origin"`
+	Count     uint64    `json:"count,omitempty"`
 }
 
 type BlockedRequestKey struct {
@@ -24,18 +29,23 @@ type BlockedRequestKey struct {
 	Origin   string
 }
 
-// BlockedRequestsAggregator keeps only the events needed to calculate an
-// exact rolling 24-hour block count. It intentionally stores no client IP,
-// request path, headers, or body.
+type blockedRequestBucketKey struct {
+	Timestamp time.Time
+	Hostname  string
+	Origin    string
+}
+
+// BlockedRequestsAggregator retains 72 hours of per-minute block counts. It
+// intentionally stores no client IP, request path, headers, or body.
 type BlockedRequestsAggregator struct {
-	mu     sync.Mutex
-	path   string
-	now    func() time.Time
-	events []BlockedRequestEvent
+	mu      sync.Mutex
+	path    string
+	now     func() time.Time
+	buckets map[blockedRequestBucketKey]uint64
 }
 
 func NewBlockedRequestsAggregator(path string) (*BlockedRequestsAggregator, error) {
-	a := &BlockedRequestsAggregator{path: path, now: time.Now}
+	a := &BlockedRequestsAggregator{path: path, now: time.Now, buckets: make(map[blockedRequestBucketKey]uint64)}
 	if err := a.load(); err != nil {
 		return a, err
 	}
@@ -47,19 +57,22 @@ func (a *BlockedRequestsAggregator) Record(hostname, origin string) (map[Blocked
 	defer a.mu.Unlock()
 
 	now := a.now().UTC()
-	a.events = append(a.events, BlockedRequestEvent{Timestamp: now, Hostname: hostname, Origin: origin})
+	bucketTime := now.Truncate(BlockedRequestsBucketDuration)
+	a.buckets[blockedRequestBucketKey{Timestamp: bucketTime, Hostname: hostname, Origin: origin}]++
 	a.pruneLocked(now)
+	snapshot := a.snapshotLocked(now, BlockedRequestsMetricWindow)
 	if err := a.saveLocked(); err != nil {
-		return a.snapshotLocked(), err
+		return snapshot, err
 	}
-	return a.snapshotLocked(), nil
+	return snapshot, nil
 }
 
-func (a *BlockedRequestsAggregator) Snapshot() map[BlockedRequestKey]uint64 {
+func (a *BlockedRequestsAggregator) Snapshot(window time.Duration) map[BlockedRequestKey]uint64 {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	a.pruneLocked(a.now().UTC())
-	return a.snapshotLocked()
+	now := a.now().UTC()
+	a.pruneLocked(now)
+	return a.snapshotLocked(now, window)
 }
 
 func (a *BlockedRequestsAggregator) load() error {
@@ -73,27 +86,39 @@ func (a *BlockedRequestsAggregator) load() error {
 	if err != nil {
 		return fmt.Errorf("read blocked request aggregation: %w", err)
 	}
-	if err := json.Unmarshal(content, &a.events); err != nil {
+	var buckets []BlockedRequestBucket
+	if err := json.Unmarshal(content, &buckets); err != nil {
 		return fmt.Errorf("decode blocked request aggregation: %w", err)
+	}
+	for _, bucket := range buckets {
+		// Version 1 stored one event per item without a count. Preserve those
+		// historical entries when upgrading to per-minute buckets.
+		if bucket.Count == 0 {
+			bucket.Count = 1
+		}
+		bucket.Timestamp = bucket.Timestamp.UTC().Truncate(BlockedRequestsBucketDuration)
+		a.buckets[blockedRequestBucketKey{Timestamp: bucket.Timestamp, Hostname: bucket.Hostname, Origin: bucket.Origin}] += bucket.Count
 	}
 	a.pruneLocked(a.now().UTC())
 	return nil
 }
 
 func (a *BlockedRequestsAggregator) pruneLocked(now time.Time) {
-	cutoff := now.Add(-BlockedRequestsAggregationWindow)
-	first := sort.Search(len(a.events), func(i int) bool {
-		return !a.events[i].Timestamp.Before(cutoff)
-	})
-	if first > 0 {
-		a.events = append([]BlockedRequestEvent(nil), a.events[first:]...)
+	cutoff := now.Add(-BlockedRequestsAggregationWindow).Truncate(BlockedRequestsBucketDuration)
+	for key := range a.buckets {
+		if key.Timestamp.Before(cutoff) {
+			delete(a.buckets, key)
+		}
 	}
 }
 
-func (a *BlockedRequestsAggregator) snapshotLocked() map[BlockedRequestKey]uint64 {
+func (a *BlockedRequestsAggregator) snapshotLocked(now time.Time, window time.Duration) map[BlockedRequestKey]uint64 {
+	cutoff := now.Add(-window).Truncate(BlockedRequestsBucketDuration)
 	snapshot := make(map[BlockedRequestKey]uint64)
-	for _, event := range a.events {
-		snapshot[BlockedRequestKey{Hostname: event.Hostname, Origin: event.Origin}]++
+	for key, count := range a.buckets {
+		if !key.Timestamp.Before(cutoff) {
+			snapshot[BlockedRequestKey{Hostname: key.Hostname, Origin: key.Origin}] += count
+		}
 	}
 	return snapshot
 }
@@ -102,7 +127,20 @@ func (a *BlockedRequestsAggregator) saveLocked() error {
 	if err := os.MkdirAll(filepath.Dir(a.path), 0o755); err != nil {
 		return fmt.Errorf("create blocked request aggregation directory: %w", err)
 	}
-	content, err := json.Marshal(a.events)
+	buckets := make([]BlockedRequestBucket, 0, len(a.buckets))
+	for key, count := range a.buckets {
+		buckets = append(buckets, BlockedRequestBucket{Timestamp: key.Timestamp, Hostname: key.Hostname, Origin: key.Origin, Count: count})
+	}
+	sort.Slice(buckets, func(i, j int) bool {
+		if !buckets[i].Timestamp.Equal(buckets[j].Timestamp) {
+			return buckets[i].Timestamp.Before(buckets[j].Timestamp)
+		}
+		if buckets[i].Hostname != buckets[j].Hostname {
+			return buckets[i].Hostname < buckets[j].Hostname
+		}
+		return buckets[i].Origin < buckets[j].Origin
+	})
+	content, err := json.Marshal(buckets)
 	if err != nil {
 		return fmt.Errorf("encode blocked request aggregation: %w", err)
 	}

--- a/mod/metrics/blocked_aggregation.go
+++ b/mod/metrics/blocked_aggregation.go
@@ -1,0 +1,130 @@
+package metrics
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+)
+
+const BlockedRequestsAggregationWindow = 24 * time.Hour
+
+type BlockedRequestEvent struct {
+	Timestamp time.Time `json:"timestamp"`
+	Hostname  string    `json:"hostname"`
+	Origin    string    `json:"origin"`
+}
+
+type BlockedRequestKey struct {
+	Hostname string
+	Origin   string
+}
+
+// BlockedRequestsAggregator keeps only the events needed to calculate an
+// exact rolling 24-hour block count. It intentionally stores no client IP,
+// request path, headers, or body.
+type BlockedRequestsAggregator struct {
+	mu     sync.Mutex
+	path   string
+	now    func() time.Time
+	events []BlockedRequestEvent
+}
+
+func NewBlockedRequestsAggregator(path string) (*BlockedRequestsAggregator, error) {
+	a := &BlockedRequestsAggregator{path: path, now: time.Now}
+	if err := a.load(); err != nil {
+		return a, err
+	}
+	return a, nil
+}
+
+func (a *BlockedRequestsAggregator) Record(hostname, origin string) (map[BlockedRequestKey]uint64, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	now := a.now().UTC()
+	a.events = append(a.events, BlockedRequestEvent{Timestamp: now, Hostname: hostname, Origin: origin})
+	a.pruneLocked(now)
+	if err := a.saveLocked(); err != nil {
+		return a.snapshotLocked(), err
+	}
+	return a.snapshotLocked(), nil
+}
+
+func (a *BlockedRequestsAggregator) Snapshot() map[BlockedRequestKey]uint64 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.pruneLocked(a.now().UTC())
+	return a.snapshotLocked()
+}
+
+func (a *BlockedRequestsAggregator) load() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	content, err := os.ReadFile(a.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read blocked request aggregation: %w", err)
+	}
+	if err := json.Unmarshal(content, &a.events); err != nil {
+		return fmt.Errorf("decode blocked request aggregation: %w", err)
+	}
+	a.pruneLocked(a.now().UTC())
+	return nil
+}
+
+func (a *BlockedRequestsAggregator) pruneLocked(now time.Time) {
+	cutoff := now.Add(-BlockedRequestsAggregationWindow)
+	first := sort.Search(len(a.events), func(i int) bool {
+		return !a.events[i].Timestamp.Before(cutoff)
+	})
+	if first > 0 {
+		a.events = append([]BlockedRequestEvent(nil), a.events[first:]...)
+	}
+}
+
+func (a *BlockedRequestsAggregator) snapshotLocked() map[BlockedRequestKey]uint64 {
+	snapshot := make(map[BlockedRequestKey]uint64)
+	for _, event := range a.events {
+		snapshot[BlockedRequestKey{Hostname: event.Hostname, Origin: event.Origin}]++
+	}
+	return snapshot
+}
+
+func (a *BlockedRequestsAggregator) saveLocked() error {
+	if err := os.MkdirAll(filepath.Dir(a.path), 0o755); err != nil {
+		return fmt.Errorf("create blocked request aggregation directory: %w", err)
+	}
+	content, err := json.Marshal(a.events)
+	if err != nil {
+		return fmt.Errorf("encode blocked request aggregation: %w", err)
+	}
+	temporary, err := os.CreateTemp(filepath.Dir(a.path), ".blocked-requests-*.json")
+	if err != nil {
+		return fmt.Errorf("create blocked request aggregation temporary file: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if _, err := temporary.Write(content); err != nil {
+		temporary.Close()
+		return fmt.Errorf("write blocked request aggregation: %w", err)
+	}
+	if err := temporary.Chmod(0o600); err != nil {
+		temporary.Close()
+		return fmt.Errorf("set blocked request aggregation permissions: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close blocked request aggregation: %w", err)
+	}
+	if err := os.Rename(temporaryPath, a.path); err != nil {
+		return fmt.Errorf("replace blocked request aggregation: %w", err)
+	}
+	return nil
+}

--- a/mod/metrics/blocked_aggregation_test.go
+++ b/mod/metrics/blocked_aggregation_test.go
@@ -6,9 +6,9 @@ import (
 	"time"
 )
 
-func TestBlockedRequestsAggregatorPersistsAndPrunesEvents(t *testing.T) {
+func TestBlockedRequestsAggregatorPersistsMinuteBucketsAndRetains72Hours(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "blocked-requests-24h.json")
-	base := time.Date(2026, time.August, 11, 12, 0, 0, 0, time.UTC)
+	base := time.Date(2026, time.August, 11, 12, 0, 15, 0, time.UTC)
 
 	aggregator, err := NewBlockedRequestsAggregator(path)
 	if err != nil {
@@ -18,6 +18,7 @@ func TestBlockedRequestsAggregatorPersistsAndPrunesEvents(t *testing.T) {
 	if _, err := aggregator.Record("home.example", "crowdsec"); err != nil {
 		t.Fatalf("Record() error = %v", err)
 	}
+	aggregator.now = func() time.Time { return base.Add(30 * time.Second) }
 	if _, err := aggregator.Record("home.example", "crowdsec"); err != nil {
 		t.Fatalf("Record() error = %v", err)
 	}
@@ -26,13 +27,16 @@ func TestBlockedRequestsAggregatorPersistsAndPrunesEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewBlockedRequestsAggregator(reload) error = %v", err)
 	}
-	reloaded.now = func() time.Time { return base.Add(23 * time.Hour) }
-	if got := reloaded.Snapshot()[BlockedRequestKey{Hostname: "home.example", Origin: "crowdsec"}]; got != 2 {
-		t.Fatalf("persisted count = %d, want 2", got)
+	reloaded.now = func() time.Time { return base.Add(25 * time.Hour) }
+	if got := len(reloaded.Snapshot(BlockedRequestsMetricWindow)); got != 0 {
+		t.Fatalf("24-hour snapshot length = %d, want 0", got)
+	}
+	if got := reloaded.Snapshot(BlockedRequestsAggregationWindow)[BlockedRequestKey{Hostname: "home.example", Origin: "crowdsec"}]; got != 2 {
+		t.Fatalf("72-hour retained count = %d, want 2", got)
 	}
 
-	reloaded.now = func() time.Time { return base.Add(25 * time.Hour) }
-	if got := len(reloaded.Snapshot()); got != 0 {
-		t.Fatalf("pruned snapshot length = %d, want 0", got)
+	reloaded.now = func() time.Time { return base.Add(73 * time.Hour) }
+	if got := len(reloaded.Snapshot(BlockedRequestsAggregationWindow)); got != 0 {
+		t.Fatalf("72-hour snapshot length = %d, want 0", got)
 	}
 }

--- a/mod/metrics/blocked_aggregation_test.go
+++ b/mod/metrics/blocked_aggregation_test.go
@@ -1,0 +1,38 @@
+package metrics
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestBlockedRequestsAggregatorPersistsAndPrunesEvents(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "blocked-requests-24h.json")
+	base := time.Date(2026, time.August, 11, 12, 0, 0, 0, time.UTC)
+
+	aggregator, err := NewBlockedRequestsAggregator(path)
+	if err != nil {
+		t.Fatalf("NewBlockedRequestsAggregator() error = %v", err)
+	}
+	aggregator.now = func() time.Time { return base }
+	if _, err := aggregator.Record("home.example", "crowdsec"); err != nil {
+		t.Fatalf("Record() error = %v", err)
+	}
+	if _, err := aggregator.Record("home.example", "crowdsec"); err != nil {
+		t.Fatalf("Record() error = %v", err)
+	}
+
+	reloaded, err := NewBlockedRequestsAggregator(path)
+	if err != nil {
+		t.Fatalf("NewBlockedRequestsAggregator(reload) error = %v", err)
+	}
+	reloaded.now = func() time.Time { return base.Add(23 * time.Hour) }
+	if got := reloaded.Snapshot()[BlockedRequestKey{Hostname: "home.example", Origin: "crowdsec"}]; got != 2 {
+		t.Fatalf("persisted count = %d, want 2", got)
+	}
+
+	reloaded.now = func() time.Time { return base.Add(25 * time.Hour) }
+	if got := len(reloaded.Snapshot()); got != 0 {
+		t.Fatalf("pruned snapshot length = %d, want 0", got)
+	}
+}

--- a/mod/metrics/blocked_aggregation_test.go
+++ b/mod/metrics/blocked_aggregation_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -38,5 +39,37 @@ func TestBlockedRequestsAggregatorPersistsMinuteBucketsAndRetains72Hours(t *test
 	reloaded.now = func() time.Time { return base.Add(73 * time.Hour) }
 	if got := len(reloaded.Snapshot(BlockedRequestsAggregationWindow)); got != 0 {
 		t.Fatalf("72-hour snapshot length = %d, want 0", got)
+	}
+}
+
+func TestBlockedRequestsAggregatorLoadsSampleData(t *testing.T) {
+	fixturePath := filepath.Join("testdata", "blocked-requests-sample.json")
+	content, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", fixturePath, err)
+	}
+	path := filepath.Join(t.TempDir(), "blocked-requests-24h.json")
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	now := time.Date(2026, time.August, 11, 14, 42, 0, 0, time.UTC)
+	aggregator, err := newBlockedRequestsAggregator(path, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("newBlockedRequestsAggregator() error = %v", err)
+	}
+
+	snapshot := aggregator.Snapshot(BlockedRequestsMetricWindow)
+	var total uint64
+	for _, count := range snapshot {
+		total += count
+	}
+	if total != 18 {
+		t.Fatalf("total blocks = %d, want 18", total)
+	}
+	if got := snapshot[BlockedRequestKey{Hostname: "pve2.patking73.ch", Origin: "crowdsec"}]; got != 9 {
+		t.Fatalf("pve2 CrowdSec blocks = %d, want 9", got)
+	}
+	if got := snapshot[BlockedRequestKey{Hostname: "pve2.patking73.ch", Origin: "cscli"}]; got != 5 {
+		t.Fatalf("pve2 cscli blocks = %d, want 5", got)
 	}
 }

--- a/mod/metrics/metrics.go
+++ b/mod/metrics/metrics.go
@@ -20,9 +20,12 @@ type metricName string
 type MetricUnit string
 
 const (
-	DROPPED_REQUESTS   metricName = "zoraxy_bouncer_blocked_requests"
-	PROCESSED_REQUESTS metricName = "zoraxy_bouncer_processed_requests"
+	DROPPED_REQUESTS     metricName = "zoraxy_bouncer_blocked_requests"
+	PROCESSED_REQUESTS   metricName = "zoraxy_bouncer_processed_requests"
+	DROPPED_REQUESTS_24H metricName = "zoraxy_bouncer_blocked_requests_24h"
 )
+
+const DefaultBlockedRequestsAggregationFile = "blocked-requests-24h.json"
 
 type Metric struct {
 	Name         string
@@ -39,7 +42,13 @@ func (m metricMap) MustRegisterAll() {
 	for _, met := range m {
 		prometheus.MustRegister(met.Counter)
 	}
+	prometheus.MustRegister(blockedRequests24h)
 }
+
+var blockedRequests24h = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: string(DROPPED_REQUESTS_24H),
+	Help: "Exact rolling 24-hour count of requests blocked by the Zoraxy bouncer",
+}, []string{"origin", "hostname"})
 
 var Map = metricMap{
 	DROPPED_REQUESTS: {
@@ -81,16 +90,22 @@ func getLabelValue(labels []*io_prometheus_client.LabelPair, key string) string 
 }
 
 type MetricsHandler struct {
-	Lock   sync.RWMutex
-	logger *logrus.Logger
+	Lock                      sync.RWMutex
+	logger                    *logrus.Logger
+	blockedRequestsAggregator *BlockedRequestsAggregator
 }
 
-func NewMetricsHandler(logger *logrus.Logger) *MetricsHandler {
-	// Initialization logic for MetricsHandler if needed
-	mh := &MetricsHandler{
-		logger: logger,
-		Lock:   sync.RWMutex{},
+func NewMetricsHandler(logger *logrus.Logger, aggregationPath string) *MetricsHandler {
+	aggregator, err := NewBlockedRequestsAggregator(aggregationPath)
+	if err != nil {
+		logger.WithError(err).Warn("Unable to load persisted blocked request aggregation; starting with an empty in-memory aggregation")
 	}
+	mh := &MetricsHandler{
+		logger:                    logger,
+		Lock:                      sync.RWMutex{},
+		blockedRequestsAggregator: aggregator,
+	}
+	mh.refreshBlockedRequests24hMetric(aggregator.Snapshot())
 
 	return mh
 }
@@ -101,7 +116,24 @@ func (mh *MetricsHandler) MarkRequestDropped(hostname string, decision *models.D
 
 	// Increment the dropped requests metric
 	// This is a simple counter, so we just increment the value
-	Map[DROPPED_REQUESTS].Counter.With(prometheus.Labels{"origin": *decision.Origin, "hostname": hostname}).Inc()
+	origin := "unknown"
+	if decision.Origin != nil {
+		origin = *decision.Origin
+	}
+	Map[DROPPED_REQUESTS].Counter.With(prometheus.Labels{"origin": origin, "hostname": hostname}).Inc()
+
+	snapshot, err := mh.blockedRequestsAggregator.Record(hostname, origin)
+	if err != nil {
+		mh.logger.WithError(err).Warn("Unable to persist blocked request aggregation")
+	}
+	mh.refreshBlockedRequests24hMetric(snapshot)
+}
+
+func (mh *MetricsHandler) refreshBlockedRequests24hMetric(snapshot map[BlockedRequestKey]uint64) {
+	blockedRequests24h.Reset()
+	for key, count := range snapshot {
+		blockedRequests24h.With(prometheus.Labels{"origin": key.Origin, "hostname": key.Hostname}).Set(float64(count))
+	}
 }
 
 func (mh *MetricsHandler) MarkRequestProcessed(hostname string) {
@@ -120,6 +152,7 @@ func (mh *MetricsHandler) MetricsUpdater(met *models.RemediationComponentsMetric
 
 	mh.Lock.RLock()
 	defer mh.Lock.RUnlock()
+	mh.refreshBlockedRequests24hMetric(mh.blockedRequestsAggregator.Snapshot())
 
 	// Most of the common fields are set automatically by the metrics provider
 	// We only need to care about the metrics themselves

--- a/mod/metrics/metrics.go
+++ b/mod/metrics/metrics.go
@@ -105,7 +105,7 @@ func NewMetricsHandler(logger *logrus.Logger, aggregationPath string) *MetricsHa
 		Lock:                      sync.RWMutex{},
 		blockedRequestsAggregator: aggregator,
 	}
-	mh.refreshBlockedRequests24hMetric(aggregator.Snapshot())
+	mh.refreshBlockedRequests24hMetric(aggregator.Snapshot(BlockedRequestsMetricWindow))
 
 	return mh
 }
@@ -152,7 +152,7 @@ func (mh *MetricsHandler) MetricsUpdater(met *models.RemediationComponentsMetric
 
 	mh.Lock.RLock()
 	defer mh.Lock.RUnlock()
-	mh.refreshBlockedRequests24hMetric(mh.blockedRequestsAggregator.Snapshot())
+	mh.refreshBlockedRequests24hMetric(mh.blockedRequestsAggregator.Snapshot(BlockedRequestsMetricWindow))
 
 	// Most of the common fields are set automatically by the metrics provider
 	// We only need to care about the metrics themselves

--- a/mod/metrics/metrics.go
+++ b/mod/metrics/metrics.go
@@ -24,11 +24,10 @@ const (
 	PROCESSED_REQUESTS metricName = "zoraxy_bouncer_processed_requests"
 )
 
-// NOTE: Currently, all metrics are treated as absolute counts.
 type Metric struct {
 	Name         string
 	Unit         string
-	Gauge        *prometheus.GaugeVec
+	Counter      *prometheus.CounterVec
 	LabelKeys    []string
 	LastValueMap map[string]float64 // keep last value to send deltas -- nil if absolute
 	KeyFunc      func(labels []*io_prometheus_client.LabelPair) string
@@ -38,7 +37,7 @@ type metricMap map[metricName]*Metric
 
 func (m metricMap) MustRegisterAll() {
 	for _, met := range m {
-		prometheus.MustRegister(met.Gauge)
+		prometheus.MustRegister(met.Counter)
 	}
 }
 
@@ -46,9 +45,9 @@ var Map = metricMap{
 	DROPPED_REQUESTS: {
 		Name: "dropped",
 		Unit: "request",
-		Gauge: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Counter: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: string(DROPPED_REQUESTS),
-			Help: "Denotes the total number of requests dropped by the Zoraxy bouncer",
+			Help: "Total number of requests blocked by the Zoraxy bouncer",
 		}, []string{"origin", "hostname"}),
 		LabelKeys:    []string{"origin", "hostname"},
 		LastValueMap: make(map[string]float64),
@@ -59,9 +58,9 @@ var Map = metricMap{
 	PROCESSED_REQUESTS: {
 		Name: "processed",
 		Unit: "request",
-		Gauge: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Counter: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: string(PROCESSED_REQUESTS),
-			Help: "Denotes the total number of requests processed by the Zoraxy bouncer",
+			Help: "Total number of requests processed by the Zoraxy bouncer",
 		}, []string{"hostname"}),
 		LabelKeys:    []string{"hostname"},
 		LastValueMap: make(map[string]float64),
@@ -102,7 +101,7 @@ func (mh *MetricsHandler) MarkRequestDropped(hostname string, decision *models.D
 
 	// Increment the dropped requests metric
 	// This is a simple counter, so we just increment the value
-	Map[DROPPED_REQUESTS].Gauge.With(prometheus.Labels{"origin": *decision.Origin, "hostname": hostname}).Inc()
+	Map[DROPPED_REQUESTS].Counter.With(prometheus.Labels{"origin": *decision.Origin, "hostname": hostname}).Inc()
 }
 
 func (mh *MetricsHandler) MarkRequestProcessed(hostname string) {
@@ -111,7 +110,7 @@ func (mh *MetricsHandler) MarkRequestProcessed(hostname string) {
 
 	// Increment the processed requests metric
 	// This is a simple counter, so we just increment the value
-	Map[PROCESSED_REQUESTS].Gauge.With(prometheus.Labels{"hostname": hostname}).Inc()
+	Map[PROCESSED_REQUESTS].Counter.With(prometheus.Labels{"hostname": hostname}).Inc()
 }
 
 // MetricsUpdater receives a metrics struct with basic data and populates it with the current metrics.
@@ -148,14 +147,14 @@ func (mh *MetricsHandler) MetricsUpdater(met *models.RemediationComponentsMetric
 
 		for _, metric := range pm.GetMetric() {
 			labels := metric.GetLabel()
-			gaugeValue := metric.GetGauge().GetValue()
+			counterValue := metric.GetCounter().GetValue()
 
 			labelMap := make(map[string]string)
 			for _, key := range cfg.LabelKeys {
 				labelMap[key] = getLabelValue(labels, key)
 			}
 
-			valueToReport := gaugeValue
+			valueToReport := counterValue
 			if cfg.LastValueMap == nil {
 				// always send absolute values
 				mh.logger.Debugf("Sending %s for %+v %f", cfg.Name, labelMap, valueToReport)
@@ -164,9 +163,9 @@ func (mh *MetricsHandler) MetricsUpdater(met *models.RemediationComponentsMetric
 				// because the firewall counter may have been reset since last collection.
 				key := cfg.KeyFunc(labels)
 
-				// no need to guard access to LastValueMap, as we are in the main thread -- it's
-				// the gauge that is updated by the requests
-				valueToReport = gaugeValue - cfg.LastValueMap[key]
+				// no need to guard access to LastValueMap, as we are in the main thread -- the
+				// counter is updated by the request handlers.
+				valueToReport = counterValue - cfg.LastValueMap[key]
 
 				if valueToReport < 0 {
 					valueToReport = -valueToReport
@@ -174,8 +173,8 @@ func (mh *MetricsHandler) MetricsUpdater(met *models.RemediationComponentsMetric
 					mh.logger.Warningf("metric value for %s %+v is negative, assuming external counter was reset", cfg.Name, labelMap)
 				}
 
-				cfg.LastValueMap[key] = gaugeValue
-				mh.logger.Debugf("Sending %s for %+v %f | current value: %f | previous value: %f", cfg.Name, labelMap, valueToReport, gaugeValue, cfg.LastValueMap[key])
+				cfg.LastValueMap[key] = counterValue
+				mh.logger.Debugf("Sending %s for %+v %f | current value: %f | previous value: %f", cfg.Name, labelMap, valueToReport, counterValue, cfg.LastValueMap[key])
 			}
 
 			met.Metrics[0].Items = append(met.Metrics[0].Items, &models.MetricsDetailItem{

--- a/mod/metrics/testdata/blocked-requests-sample.json
+++ b/mod/metrics/testdata/blocked-requests-sample.json
@@ -1,0 +1,26 @@
+[
+  {
+    "timestamp": "2026-08-11T14:40:00Z",
+    "hostname": "hassio.patking73.ch",
+    "origin": "crowdsec",
+    "count": 4
+  },
+  {
+    "timestamp": "2026-08-11T14:40:00Z",
+    "hostname": "pve2.patking73.ch",
+    "origin": "crowdsec",
+    "count": 4
+  },
+  {
+    "timestamp": "2026-08-11T14:40:00Z",
+    "hostname": "pve2.patking73.ch",
+    "origin": "cscli",
+    "count": 5
+  },
+  {
+    "timestamp": "2026-08-11T14:41:00Z",
+    "hostname": "pve2.patking73.ch",
+    "origin": "crowdsec",
+    "count": 5
+  }
+]

--- a/mod/web/metrics_test.go
+++ b/mod/web/metrics_test.go
@@ -1,0 +1,21 @@
+package web
+
+import "testing"
+
+func TestAddMetricValueAggregatesBlockedRequestOrigins(t *testing.T) {
+	response := MetricsResponse{
+		BlockedRequests:   make(map[string]float64),
+		ProcessedRequests: make(map[string]float64),
+	}
+
+	addMetricValue(&response, "zoraxy_bouncer_blocked_requests", "pve2.example", 9)
+	addMetricValue(&response, "zoraxy_bouncer_blocked_requests", "pve2.example", 5)
+	addMetricValue(&response, "zoraxy_bouncer_processed_requests", "pve2.example", 20)
+
+	if got := response.BlockedRequests["pve2.example"]; got != 14 {
+		t.Fatalf("blocked requests = %v, want 14", got)
+	}
+	if got := response.ProcessedRequests["pve2.example"]; got != 20 {
+		t.Fatalf("processed requests = %v, want 20", got)
+	}
+}

--- a/mod/web/prometheus_test.go
+++ b/mod/web/prometheus_test.go
@@ -14,12 +14,11 @@ func TestPrometheusMetricsHandlerExposesTextFormat(t *testing.T) {
 	metrics.Map.MustRegisterAll()
 	t.Cleanup(func() {
 		for _, metric := range metrics.Map {
-			metric.Gauge.Reset()
-			prometheus.Unregister(metric.Gauge)
+			prometheus.Unregister(metric.Counter)
 		}
 	})
-	metrics.Map[metrics.DROPPED_REQUESTS].Gauge.With(prometheus.Labels{"origin": "crowdsec", "hostname": "service.example"}).Set(3)
-	metrics.Map[metrics.PROCESSED_REQUESTS].Gauge.With(prometheus.Labels{"hostname": "service.example"}).Set(10)
+	metrics.Map[metrics.DROPPED_REQUESTS].Counter.With(prometheus.Labels{"origin": "crowdsec", "hostname": "service.example"}).Add(3)
+	metrics.Map[metrics.PROCESSED_REQUESTS].Counter.With(prometheus.Labels{"hostname": "service.example"}).Add(10)
 
 	request := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	response := httptest.NewRecorder()

--- a/mod/web/prometheus_test.go
+++ b/mod/web/prometheus_test.go
@@ -1,0 +1,41 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestPrometheusMetricsHandlerExposesTextFormat(t *testing.T) {
+	metrics.Map.MustRegisterAll()
+	t.Cleanup(func() {
+		for _, metric := range metrics.Map {
+			metric.Gauge.Reset()
+			prometheus.Unregister(metric.Gauge)
+		}
+	})
+	metrics.Map[metrics.DROPPED_REQUESTS].Gauge.With(prometheus.Labels{"origin": "crowdsec", "hostname": "service.example"}).Set(3)
+	metrics.Map[metrics.PROCESSED_REQUESTS].Gauge.With(prometheus.Labels{"hostname": "service.example"}).Set(10)
+
+	request := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	response := httptest.NewRecorder()
+	prometheusMetricsHandler().ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusOK)
+	}
+	if contentType := response.Header().Get("Content-Type"); !strings.Contains(contentType, "text/plain") {
+		t.Fatalf("Content-Type = %q, want Prometheus text format", contentType)
+	}
+	body := response.Body.String()
+	if !strings.Contains(body, "zoraxy_bouncer_blocked_requests{hostname=\"service.example\",origin=\"crowdsec\"} 3") {
+		t.Fatalf("blocked metric missing from response: %s", body)
+	}
+	if !strings.Contains(body, "zoraxy_bouncer_processed_requests{hostname=\"service.example\"} 10") {
+		t.Fatalf("processed metric missing from response: %s", body)
+	}
+}

--- a/mod/web/web.go
+++ b/mod/web/web.go
@@ -176,7 +176,7 @@ func StartPrometheusServer(logger *logrus.Logger, g *errgroup.Group, ctx context
 	g.Go(func() error {
 		logger.Infof("Prometheus metrics available at http://%s/metrics", listenAddr)
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			return fmt.Errorf("Prometheus metrics server failed: %w", err)
+			return fmt.Errorf("prometheus metrics server failed: %w", err)
 		}
 		return nil
 	})

--- a/mod/web/web.go
+++ b/mod/web/web.go
@@ -115,11 +115,7 @@ func apiMetricsHandler(w http.ResponseWriter, r *http.Request) {
 
 			value := metric.GetCounter().GetValue()
 
-			if metricName == string(metrics.DROPPED_REQUESTS) {
-				response.BlockedRequests[hostname] = value
-			} else if metricName == string(metrics.PROCESSED_REQUESTS) {
-				response.ProcessedRequests[hostname] = value
-			}
+			addMetricValue(&response, metricName, hostname, value)
 		}
 	}
 
@@ -141,6 +137,17 @@ func apiMetricsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(response)
+}
+
+// addMetricValue aggregates the same hostname across all labels. Blocked
+// request counters also carry an origin label, so assigning instead of adding
+// would silently discard one of the origins.
+func addMetricValue(response *MetricsResponse, metricName, hostname string, value float64) {
+	if metricName == string(metrics.DROPPED_REQUESTS) {
+		response.BlockedRequests[hostname] += value
+	} else if metricName == string(metrics.PROCESSED_REQUESTS) {
+		response.ProcessedRequests[hostname] += value
+	}
 }
 
 // prometheusMetricsHandler exposes the registered bouncer metrics in the

--- a/mod/web/web.go
+++ b/mod/web/web.go
@@ -13,6 +13,7 @@ import (
 	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/metrics"
 	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/zoraxy_plugin"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )
@@ -142,6 +143,17 @@ func apiMetricsHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(response)
 }
 
+// prometheusMetricsHandler exposes the registered bouncer metrics in the
+// Prometheus text exposition format. The plugin server listens on loopback, so
+// any route exposing this handler outside the host must be access-controlled.
+func prometheusMetricsHandler() http.Handler {
+	return prometheusMetricsHandlerFor(prometheus.DefaultGatherer)
+}
+
+func prometheusMetricsHandlerFor(gatherer prometheus.Gatherer) http.Handler {
+	return promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{})
+}
+
 func apiHeadersHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
@@ -266,6 +278,7 @@ func InitWebServer(logger *logrus.Logger, g *errgroup.Group, ctx context.Context
 	// Add API endpoints
 	mux.HandleFunc(info.UI_PATH+"api/version", apiVersionHandler)
 	mux.HandleFunc(info.UI_PATH+"api/metrics", apiMetricsHandler)
+	mux.Handle(info.UI_PATH+"metrics", prometheusMetricsHandler())
 	mux.HandleFunc(info.UI_PATH+"api/headers", apiHeadersHandler)
 	mux.HandleFunc(info.UI_PATH+"api/config-status", apiConfigStatusHandler)
 

--- a/mod/web/web.go
+++ b/mod/web/web.go
@@ -113,7 +113,7 @@ func apiMetricsHandler(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 
-			value := metric.GetGauge().GetValue()
+			value := metric.GetCounter().GetValue()
 
 			if metricName == string(metrics.DROPPED_REQUESTS) {
 				response.BlockedRequests[hostname] = value

--- a/mod/web/web.go
+++ b/mod/web/web.go
@@ -154,6 +154,31 @@ func prometheusMetricsHandlerFor(gatherer prometheus.Gatherer) http.Handler {
 	return promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{})
 }
 
+// StartPrometheusServer starts an optional dedicated listener for Prometheus.
+// Callers should bind it only to a trusted network interface.
+func StartPrometheusServer(logger *logrus.Logger, g *errgroup.Group, ctx context.Context, listenAddr string) {
+	if listenAddr == "" {
+		return
+	}
+
+	server := &http.Server{
+		Addr:    listenAddr,
+		Handler: prometheusMetricsHandler(),
+	}
+
+	g.Go(func() error {
+		logger.Infof("Prometheus metrics available at http://%s/metrics", listenAddr)
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			return fmt.Errorf("Prometheus metrics server failed: %w", err)
+		}
+		return nil
+	})
+	g.Go(func() error {
+		<-ctx.Done()
+		return ShutdownWebServer(server, 30*time.Second)
+	})
+}
+
 func apiHeadersHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 

--- a/tools/standalone_ui.go
+++ b/tools/standalone_ui.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/config"
+	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/metrics"
 	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/utils"
 	"github.com/AnthonyMichaelTDM/zoraxycrowdsecbouncer/mod/web"
 	"github.com/sirupsen/logrus"
@@ -34,6 +35,7 @@ func main() {
 	logger.Level = config.LogLevel
 
 	g, ctx := errgroup.WithContext(context.Background())
+	metrics.Map.MustRegisterAll()
 
 	// Initialize the web UI
 	web.InitWebServer(logger, g, ctx, PORT, web.ConfigStatusResponse{


### PR DESCRIPTION
Closes #42

## What changed
- Adds an optional dedicated Prometheus listener via `prometheus_listen_addr`.
- Exposes blocked and processed request totals as Prometheus counters.
- Persists blocked-request aggregation as 72 hours of per-minute JSON buckets and exports `zoraxy_bouncer_blocked_requests_24h`.
- Aggregates multiple CrowdSec origins for the same hostname in the Zoraxy UI instead of overwriting one origin with another.
- Documents trusted-network guidance for the metrics listener.

## Test data
- Includes a captured, privacy-minimised aggregation fixture: timestamp, hostname, origin, and count only; no client IP, request path, headers, or body.
- Fixture test verifies the 24-hour total (18) and aggregation of the `pve2.patking73.ch` CrowdSec and cscli origins.

## Validation
- `go test ./...`
- Linux/amd64 build completed.
- Production validation: Zoraxy metrics endpoint and Prometheus scrape target are healthy; Grafana displays the 24-hour aggregate.